### PR TITLE
Fix fetch query and button handler type

### DIFF
--- a/types/index.ts
+++ b/types/index.ts
@@ -3,8 +3,7 @@ import { MouseEventHandler } from "react";
 export interface CustomButtonProps {
     title : string;
     containerStyles?: string;
-    handleClick?: 
-    MouseEventHandler<HTMLButtonElement>;
+    handleClick?: MouseEventHandler<HTMLButtonElement>;
     btnType?: "button" | "submit";
     textStyles?: string;
     rightIcon?: string;

--- a/utils/index.ts
+++ b/utils/index.ts
@@ -7,7 +7,10 @@ export async function fetchCar( filters: FilterProps) {
         'X-RapidAPI-Key': '058bbea680msh03b297ea12b27b6p1397fajsn8a6a350cf5a0',
 		'X-RapidAPI-Host': 'cars-by-api-ninjas.p.rapidapi.com'
     }
-    const response = await fetch(`https://cars-by-api-ninjas.p.rapidapi.com/v1/cars?make=${manufacturer}&year=${year}&limit=${limit}&fule=${fuel}&model=${model}`, {headers: headers});
+    const response = await fetch(
+        `https://cars-by-api-ninjas.p.rapidapi.com/v1/cars?make=${manufacturer}&year=${year}&limit=${limit}&fuel=${fuel}&model=${model}`,
+        { headers: headers }
+    );
 
     const result = await response.json();
 


### PR DESCRIPTION
## Summary
- correctly pass fuel in car API query
- type CustomButton button click handler

## Testing
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_6895c428bf6c832085622f45605e56de